### PR TITLE
Spellbook Skin and basic skinning of LFD/PvP windows

### DIFF
--- a/ElvUI/Modules/Skins/Blizzard/LFD.lua
+++ b/ElvUI/Modules/Skins/Blizzard/LFD.lua
@@ -21,12 +21,14 @@ S:AddCallback("Skin_LFD", function()
 	AscensionLFGFrameMenu:StripTextures(true)
 	AscensionLFGFrameInset:StripTextures(true)
 	AscensionLFGFrameInset:CreateBackdrop("Transparent")
+	AscensionLFGFrameInsetNineSlice:StripTextures(true)
 	AscensionLFGFrameNineSlice:StripTextures(true)
 	AscensionLFGFrameMenuNineSlice:StripTextures(true)
 
 	AscensionPVEFrameLFDFrame:StripTextures(true)
 	AscensionPVEFrameLFDFrame:CreateBackdrop("Transparent")
 	AscensionPVEFrameLFDFrameRandom:StripTextures(true)
+	AscensionPVEFrameLFDFrameRandomScrollFrame:StripTextures(true)
 
 	S:HookScript(LFDParentFrame, "OnShow", function(self)
 		S:SetUIPanelWindowInfo(self, "width", 341)
@@ -84,14 +86,13 @@ S:AddCallback("Skin_LFD", function()
 	S:HandleButton(sidebutton)
 	end
 
-	--[[Tabs (will come back to this... will investigate)
+	--Tabs
 	for i = 1, 3 do
-		local frame = _G["AscensionLFGFrameTab"..i]
-		S:HandleButton(frame)
-		--frame:StripTextures(true)
-		frame:Size(10,22)
+		local tab = _G["AscensionLFGFrameTab"..i]
+		tab:Size(122, 32)
+		tab:GetRegions():SetPoint("CENTER", 0, 2)
+		S:HandleTab(tab)
 	end
-	]]--
 	
 	S:HandleButton(AscensionPVEFrameLFDFrameFindGroupButton)
 	--S:HandleButton(AscensionPVEFrameLFDFrameCancelButton)
@@ -137,6 +138,7 @@ S:AddCallback("Skin_LFD", function()
 		AscensionPVPFrameCasualFrame:CreateBackdrop("Transparent")
 		AscensionPVPFrameCasualFrameInset:StripTextures(true)
 		AscensionPVPFrameCasualFrameInset:CreateBackdrop("Transparent")
+		AscensionPVPFrameCasualFrameInsetNineSlice:StripTextures(true)
 			-- Buttons (Queues)
 			S:HandleButton(AscensionPVPFrameCasualFrameRandomBGButton)
 			S:HandleButton(AscensionPVPFrameCasualFrameCallToArmsButton1)
@@ -146,6 +148,7 @@ S:AddCallback("Skin_LFD", function()
 		-- Honor Section
 		AscensionPVPFrameHonorInset:StripTextures(true)
 		AscensionPVPFrameHonorInset:CreateBackdrop("Transparent")
+		AscensionPVPFrameHonorInsetNineSlice:StripTextures(true)
 
 		-- Buttons
 		S:HandleButton(AscensionPVPFrameCasualFrameQueueButton)
@@ -156,6 +159,7 @@ S:AddCallback("Skin_LFD", function()
 		AscensionPVPFrameRatedFrame:CreateBackdrop("Transparent")
 		AscensionPVPFrameRatedFrameInset:StripTextures(true)
 		AscensionPVPFrameRatedFrameInset:CreateBackdrop("Transparent")
+		AscensionPVPFrameRatedFrameInsetNineSlice:StripTextures(true)
 			-- Buttons (Rated)
 			S:HandleButton(AscensionPVPFrameRatedFrameArena1v1)
 			S:HandleButton(AscensionPVPFrameRatedFrameArena2v2)

--- a/ElvUI/Modules/Skins/Blizzard/Spellbook.lua
+++ b/ElvUI/Modules/Skins/Blizzard/Spellbook.lua
@@ -12,6 +12,74 @@ local MAX_SKILLLINE_TABS = MAX_SKILLLINE_TABS
 S:AddCallback("Skin_Spellbook", function()
 	if not E.private.skins.blizzard.enable or not E.private.skins.blizzard.spellbook then return end
 
+	-- AscensionSpellbook
+
+	AscensionSpellbookFrame:StripTextures(true)
+	AscensionSpellbookFrame:CreateBackdrop("Transparent")
+	AscensionSpellbookFrameNineSlice:StripTextures(true)
+	--AscensionSpellbookFrameNineSlice:CreateBackdrop("Transparent")
+	AscensionSpellbookFrameInset:StripTextures(true)
+	AscensionSpellbookFrameInset:CreateBackdrop("Transparent")
+
+	for i = 1, 3 do
+		local tab = _G["AscensionSpellbookFrameTab"..i]
+		tab:Size(122, 32)
+		--tab:GetNormalTexture():StripTextures(true)
+		--tab:GetDisabledTexture():StripTextures(true)
+		tab:GetRegions():SetPoint("CENTER", 0, 2)
+		S:HandleTab(tab)
+	end
+
+	AscensionSpellbookFrameTab1:Point("CENTER", AscensionSpellbookFrame, "BOTTOMLEFT", 72, 62)
+	AscensionSpellbookFrameTab2:Point("LEFT", AscensionSpellbookFrameTab1, "RIGHT", -15, 0)
+	AscensionSpellbookFrameTab3:Point("LEFT", AscensionSpellbookFrameTab2, "RIGHT", -15, 0)
+
+	S:HandleNextPrevButton(AscensionSpellbookFramePreviousPageButton, nil, nil, true)
+	S:HandleNextPrevButton(AscensionSpellbookFrameNextPageButton, nil, nil, true)
+
+	S:HandleCloseButton(AscensionSpellbookFrameCloseButton)
+
+	S:HandleCheckBox(AscensionSpellbookFrameContentSpellsShowAllSpellRanks)
+
+	for i = 1, SPELLS_PER_PAGE do
+		local button = _G["AscensionSpellbookFrameContentSpellsSpellButton"..i]
+		local autoCast = _G["AscensionSpellbookFrameContentSpellsSpellButton"..i.."AutoCastable"]
+		button:StripTextures()
+
+		autoCast:SetTexture("Interface\\Buttons\\UI-AutoCastableOverlay")
+		autoCast:SetOutside(button, 16, 16)
+
+		button:CreateBackdrop("Default", true)
+
+		_G["AscensionSpellbookFrameContentSpellsSpellButton"..i.."IconTexture"]:SetTexCoord(unpack(E.TexCoords))
+
+		E:RegisterCooldown(_G["AscensionSpellbookFrameContentSpellsSpellButton"..i.."Cooldown"])
+	end
+
+	hooksecurefunc("SpellButton_UpdateButton", function(self)
+		local name = self:GetName()
+		_G[name.."SpellName"]:SetTextColor(1, 0.80, 0.10)
+		_G[name.."SubSpellName"]:SetTextColor(1, 1, 1)
+		_G[name.."Highlight"]:SetTexture(1, 1, 1, 0.3)
+	end)
+
+	for i = 1, MAX_SKILLLINE_TABS do
+		local tab = _G["AscensionSpellbookFrameSideBarTab"..i]
+
+		tab:StripTextures()
+		tab:StyleButton(nil, true)
+		tab:SetTemplate("Default", true)
+
+		tab:GetNormalTexture():SetInside()
+		tab:GetNormalTexture():SetTexCoord(unpack(E.TexCoords))
+	end
+
+	AscensionSpellbookFrameSideBarTab1:Point("TOPLEFT", AscensionSpellbookFrame, "TOPRIGHT")
+
+	SpellBookPageText:SetTextColor(1, 1, 1)
+
+
+	-- Blizz Spellbook (Leaving here for now)
 	SpellBookFrame:StripTextures(true)
 	SpellBookFrame:CreateBackdrop("Transparent")
 	SpellBookFrame.backdrop:Point("TOPLEFT", 11, -12)


### PR DESCRIPTION
Here is the fix for the new Ascension Spellbook.

I kept the original spellbook code as this is still in the game
This also includes the skinning of the LFD/PvP windows.
Although not 100% complete, this should be good to run with for now until I can figure out how to remove/skin the bar between the side menu buttons and the content frames.